### PR TITLE
Wip

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -316,7 +316,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     Messages applicantMessages = messagesApi.preferred(request);
 
     // Validation errors: re-render this block with errors and previously entered data.
-    if (thisBlockUpdated.hasErrors()) {
+    if (thisBlockUpdated.hasErrors()
+        || thisBlockUpdated.hasRequiredQuestionsThatAreUnansweredInCurrentProgram()) {
       return supplyAsync(
           () ->
               ok(

--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -79,7 +79,8 @@ public enum MessageKey {
   TOAST_APPLICATION_SAVED("toast.applicationSaved"),
   TOAST_LOCALE_NOT_SUPPORTED("toast.localeNotSupported"),
   TOAST_PROGRAM_COMPLETED("toast.programCompleted"),
-  USER_NAME("header.userName");
+  USER_NAME("header.userName"),
+  VALIDATION_REQUIRED("validation.isRequired");
 
   private final String keyName;
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -248,10 +248,14 @@ public class ApplicantData {
     }
   }
 
-  /** Delete whatever is there. */
-  public void delete(Path path) {
+  /** Delete whatever is there if it exists. Returns whether a delete actually happened. */
+  public boolean maybeDelete(Path path) {
     checkLocked();
-    jsonData.delete(path.toString());
+    if (hasPath(path)) {
+      jsonData.delete(path.toString());
+      return true;
+    }
+    return false;
   }
 
   private void putAt(Path path, Object value) {

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -249,7 +249,7 @@ public class ApplicantData {
   }
 
   /** Delete whatever is there. */
-  public boolean delete(Path path) {
+  public void delete(Path path) {
     checkLocked();
     jsonData.delete(path.toString());
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -237,8 +237,8 @@ public class ApplicantData {
   }
 
   /**
-   * Clears an array in preparation of updates, regardless of whether there are anything values
-   * present.
+   * Clears an array in preparation of updates if the path is pointing to an array element,
+   * regardless of whether there are any values present.
    */
   public void maybeClearArray(Path path) {
     checkLocked();
@@ -246,6 +246,12 @@ public class ApplicantData {
       putParentIfMissing(path);
       jsonData.delete(path.withoutArrayReference().toString());
     }
+  }
+
+  /** Delete whatever is there. */
+  public boolean delete(Path path) {
+    checkLocked();
+    jsonData.delete(path.toString());
   }
 
   private void putAt(Path path, Object value) {

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -485,7 +485,7 @@ public class ApplicantServiceImpl implements ApplicantService {
               .getScalarType(currentPath)
               .orElseThrow(() -> new PathNotInBlockException(block.getId(), currentPath));
       // An empty update means the applicant doesn't want to store anything.
-      if (update.value().isBlank()) {
+      if (!update.path().isArrayElement() && update.value().isBlank()) {
         applicantData.maybeDelete(update.path());
       } else {
         switch (type) {

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -484,7 +484,10 @@ public class ApplicantServiceImpl implements ApplicantService {
           block
               .getScalarType(currentPath)
               .orElseThrow(() -> new PathNotInBlockException(block.getId(), currentPath));
-      if (!update.value().isBlank()) {
+      // An empty update means the applicant doesn't want to store anything.
+      if (update.value().isBlank()) {
+        applicantData.delete(update.path());
+      } else {
         switch (type) {
           case DATE:
             applicantData.putDate(currentPath, update.value());

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -393,8 +393,8 @@ public class ApplicantServiceImpl implements ApplicantService {
     }
 
     // Before adding anything, if only metadata is being stored then delete it
-    if (applicantData.hasPath(enumeratorPath.withoutArrayReference())) {
-      applicantData.delete(enumeratorPath.withoutArrayReference());
+    if (applicantData.readRepeatedEntities(enumeratorPath).isEmpty()) {
+      applicantData.maybeDelete(enumeratorPath.withoutArrayReference());
     }
 
     // Add and change entity names BEFORE deleting, because if deletes happened first, then changed
@@ -486,7 +486,7 @@ public class ApplicantServiceImpl implements ApplicantService {
               .orElseThrow(() -> new PathNotInBlockException(block.getId(), currentPath));
       // An empty update means the applicant doesn't want to store anything.
       if (update.value().isBlank()) {
-        applicantData.delete(update.path());
+        applicantData.maybeDelete(update.path());
       } else {
         switch (type) {
           case DATE:

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -152,6 +152,15 @@ public final class Block {
   }
 
   /**
+   * Return true if any of this blocks questions are required but were left unanswered while filling
+   * out the current program.
+   */
+  public boolean hasRequiredQuestionsThatAreUnansweredInCurrentProgram() {
+    return getQuestions().stream()
+        .anyMatch(ApplicantQuestion::isRequiredButWasUnansweredInCurrentProgram);
+  }
+
+  /**
    * Checks whether the block is complete - that is, {@link ApplicantData} has values at all the
    * paths for all required questions in this block and there are no errors. Note: this cannot be
    * memoized, since we need to reflect internal changes to ApplicantData.

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -77,6 +77,20 @@ public class ApplicantQuestion {
   }
 
   /**
+   * Return true this question is required but was left unanswered while filling out the current
+   * program.
+   */
+  public boolean isRequiredButWasUnansweredInCurrentProgram() {
+    return !isOptional() && !errorsPresenter().isAnswered() && wasRecentlyUpdated();
+  }
+
+  /** Returns true if this question was most recently updated in this program. */
+  private boolean wasRecentlyUpdated() {
+    return getUpdatedInProgramMetadata().stream()
+        .anyMatch(pid -> pid.equals(programQuestionDefinition.getProgramDefinitionId()));
+  }
+
+  /**
    * Get the question text localized to the applicant's preferred locale, contextualized with {@link
    * RepeatedEntity}.
    */

--- a/universal-application-tool-0.0.1/app/services/program/ProgramQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramQuestionDefinition.java
@@ -41,6 +41,11 @@ public abstract class ProgramQuestionDefinition {
   abstract Optional<QuestionDefinition> questionDefinition();
 
   @JsonIgnore
+  public long getProgramDefinitionId() {
+    return programDefinitionId().get();
+  }
+
+  @JsonIgnore
   public QuestionDefinition getQuestionDefinition() {
     return questionDefinition().get();
   }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.div;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import play.i18n.Messages;
+import services.MessageKey;
 import services.applicant.question.ApplicantQuestion;
 import views.BaseHtmlView;
 import views.components.TextFormatter;
@@ -65,9 +66,17 @@ public abstract class ApplicantQuestionRenderer {
       questionTextDiv.with(BaseHtmlView.fieldErrors(messages, question.getQuestionErrors()));
     }
 
+    if (question.isRequiredButWasUnansweredInCurrentProgram()) {
+      String requiredQuestionMessage = messages.at(MessageKey.VALIDATION_REQUIRED.getKeyName());
+      questionTextDiv.with(
+          div()
+              .withClasses(Styles.P_1, Styles.TEXT_RED_600)
+              .withText("*" + requiredQuestionMessage));
+    }
+
     return div()
         .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.MB_8, this.getReferenceClass(), this.getRequiredClass())
+        .withClasses(Styles.MX_AUTO, Styles.MB_8, getReferenceClass(), getRequiredClass())
         .with(questionTextDiv)
         .with(questionFormContent);
   }

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -28,6 +28,9 @@ footer.supportLinkDescription=For technical support, contact
 # Message with user's name to show who you are logged in as.
 header.userName=Logged in as {0}
 
+# Error message to answer a required question
+validation.isRequired=This question is required.
+
 #-------------------------------------------------------------#
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#

--- a/universal-application-tool-0.0.1/conf/messages.en-US
+++ b/universal-application-tool-0.0.1/conf/messages.en-US
@@ -60,6 +60,7 @@ placeholder.lastName=Last name
 placeholder.entityName=Nickname for {0}
 button.addEntity=Add {0}
 button.removeEntity=Remove {0}
+validation.isRequired=This question is required.
 validation.duplicateEntityName=Please enter a unique value for each line.
 validation.firstNameRequired=Please enter your first name.
 validation.lastNameRequired=Please enter your last name.

--- a/universal-application-tool-0.0.1/conf/messages.es-US
+++ b/universal-application-tool-0.0.1/conf/messages.es-US
@@ -59,4 +59,5 @@ placeholder.entityName=Apodo para {0}
 button.addEntity=Agrega otro {0}
 button.removeEntity=Eliminar {0}
 
+validation.isRequired=Esta pregunta es requerida.
 validation.entityNameRequired=Ingrese un valor para cada línea.

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -562,7 +562,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newDraftProgram()
             .withBlock("block 1")
-            .withQuestion(testQuestionBank().applicantFile())
+            .withQuestion(testQuestionBank().applicantFile(), true)
             .withBlock("block 2")
             .withQuestion(testQuestionBank().applicantAddress())
             .build();
@@ -594,7 +594,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newDraftProgram()
             .withBlock("block 1")
-            .withQuestion(testQuestionBank().applicantFile())
+            .withQuestion(testQuestionBank().applicantFile(), true)
             .build();
 
     RequestBuilder request =

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -368,6 +368,116 @@ public class BlockTest {
     assertThat(block.isFileUpload()).isFalse();
   }
 
+  @Test
+  public void hasRequiredQuestionsThatAreUnansweredInCurrentProgram_returnsTrue() {
+    long programId = 5L;
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(20L)
+            .setName("")
+            .setDescription("")
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .build();
+    ApplicantData applicantData = new ApplicantData();
+    Block block = new Block("id", blockDefinition, applicantData, Optional.empty());
+
+    block.getQuestions().stream()
+        .map(ApplicantQuestion::getContextualizedPath)
+        .forEach(path -> QuestionAnswerer.addMetadata(applicantData, path, programId, 1L));
+
+    assertThat(block.hasRequiredQuestionsThatAreUnansweredInCurrentProgram()).isTrue();
+  }
+
+  @Test
+  public void
+      hasRequiredQuestionsThatAreUnansweredInCurrentProgram_questionsAnsweredInAnotherProgram_returnsFalse() {
+    long programId = 5L;
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(20L)
+            .setName("")
+            .setDescription("")
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .build();
+    ApplicantData applicantData = new ApplicantData();
+    Block block = new Block("id", blockDefinition, applicantData, Optional.empty());
+
+    block.getQuestions().stream()
+        .map(ApplicantQuestion::getContextualizedPath)
+        .forEach(path -> QuestionAnswerer.addMetadata(applicantData, path, programId + 1, 1L));
+
+    assertThat(block.hasRequiredQuestionsThatAreUnansweredInCurrentProgram()).isFalse();
+  }
+
+  @Test
+  public void
+      hasRequiredQuestionsThatAreUnansweredInCurrentProgram_withOptionalQuestions_returnsFalse() {
+    long programId = 5L;
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(20L)
+            .setName("")
+            .setDescription("")
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                        testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                        Optional.of(programId))
+                    .setOptional(true))
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                        testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                        Optional.of(programId))
+                    .setOptional(true))
+            .build();
+    ApplicantData applicantData = new ApplicantData();
+    Block block = new Block("id", blockDefinition, applicantData, Optional.empty());
+
+    assertThat(block.hasRequiredQuestionsThatAreUnansweredInCurrentProgram()).isFalse();
+  }
+
+  @Test
+  public void
+      hasRequiredQuestionsThatAreUnansweredInCurrentProgram_withAnsweredQuestions_returnsFalse() {
+    long programId = 5L;
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(20L)
+            .setName("")
+            .setDescription("")
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .build();
+    ApplicantData applicantData = new ApplicantData();
+    Block block = new Block("id", blockDefinition, applicantData, Optional.empty());
+
+    QuestionAnswerer.answerNumberQuestion(
+        applicantData, block.getQuestions().get(0).getContextualizedPath(), "5");
+    QuestionAnswerer.answerTextQuestion(
+        applicantData, block.getQuestions().get(1).getContextualizedPath(), "brown");
+
+    assertThat(block.hasRequiredQuestionsThatAreUnansweredInCurrentProgram()).isFalse();
+  }
+
   private static BlockDefinition setUpBlockWithQuestions() {
     return BlockDefinition.builder()
         .setId(20L)

--- a/universal-application-tool-0.0.1/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/ApplicantQuestionTest.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.RepeatedEntity;
+import services.program.ProgramQuestionDefinition;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
@@ -285,5 +286,73 @@ public class ApplicantQuestionTest {
 
     assertThat(applicantQuestion.getUpdatedInProgramMetadata()).contains(1L);
     assertThat(applicantQuestion.getLastUpdatedTimeMetadata()).contains(2L);
+  }
+
+  @Test
+  public void isRequiredButWasUnansweredInCurrentProgram_returnsTrue() {
+    ApplicantData applicantData = new ApplicantData();
+    long programId = 5L;
+    ProgramQuestionDefinition pqd =
+        ProgramQuestionDefinition.create(
+            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            Optional.of(programId));
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(pqd, applicantData, Optional.empty());
+    QuestionAnswerer.addMetadata(
+        applicantData, applicantQuestion.getContextualizedPath(), programId, 1L);
+
+    assertThat(applicantQuestion.isRequiredButWasUnansweredInCurrentProgram()).isTrue();
+  }
+
+  @Test
+  public void
+      isRequiredButWasUnansweredInCurrentProgram_leftUnansweredInDifferentProgram_returnsFalse() {
+    ApplicantData applicantData = new ApplicantData();
+    long programId = 5L;
+    ProgramQuestionDefinition pqd =
+        ProgramQuestionDefinition.create(
+            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            Optional.of(programId));
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(pqd, applicantData, Optional.empty());
+    QuestionAnswerer.addMetadata(
+        applicantData, applicantQuestion.getContextualizedPath(), programId + 1, 1L);
+
+    assertThat(applicantQuestion.isRequiredButWasUnansweredInCurrentProgram()).isFalse();
+  }
+
+  @Test
+  public void isRequiredButWasUnansweredInCurrentProgram_isAnswered_returnsFalse() {
+    ApplicantData applicantData = new ApplicantData();
+    long programId = 5L;
+    ProgramQuestionDefinition pqd =
+        ProgramQuestionDefinition.create(
+            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            Optional.of(programId));
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(pqd, applicantData, Optional.empty());
+    QuestionAnswerer.answerNumberQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), "5");
+    QuestionAnswerer.addMetadata(
+        applicantData, applicantQuestion.getContextualizedPath(), programId, 1L);
+
+    assertThat(applicantQuestion.isRequiredButWasUnansweredInCurrentProgram()).isFalse();
+  }
+
+  @Test
+  public void isRequiredButWasUnansweredInCurrentProgram_isOptional_returnsFalse() {
+    ApplicantData applicantData = new ApplicantData();
+    long programId = 5L;
+    ProgramQuestionDefinition pqd =
+        ProgramQuestionDefinition.create(
+                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                Optional.of(programId))
+            .setOptional(true);
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(pqd, applicantData, Optional.empty());
+    QuestionAnswerer.addMetadata(
+        applicantData, applicantQuestion.getContextualizedPath(), programId, 1L);
+
+    assertThat(applicantQuestion.isRequiredButWasUnansweredInCurrentProgram()).isFalse();
   }
 }

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
@@ -202,10 +202,19 @@ public class ProgramBuilder {
       return this;
     }
 
+    /** Add a required question to the block. */
     public BlockBuilder withQuestion(Question question) {
       blockDefBuilder.addQuestion(
           ProgramQuestionDefinition.create(
               question.getQuestionDefinition(), Optional.of(programBuilder.programDefinitionId)));
+      return this;
+    }
+
+    public BlockBuilder withQuestion(Question question, boolean optional) {
+      blockDefBuilder.addQuestion(
+          ProgramQuestionDefinition.create(
+                  question.getQuestionDefinition(), Optional.of(programBuilder.programDefinitionId))
+              .setOptional(optional));
       return this;
     }
 


### PR DESCRIPTION
### Description
Add validation for required questions.

Adds `ApplicantQuestion#isRequiredButWasUnansweredInCurrentProgram`, and `ApplicantQuestionRenderer` uses that method to show an "question is required" error message.

A similar method is added to `Block`, which is used by `ApplicantProgramBlocksController` to hold up application progression the same way `Block#hasErrors()` blocks progress.

Had to implement `empty updates -> deleting json data` to make things work well. Also had to implement `delete enumerator metadata if its the only thing at that path` for similar reasons.